### PR TITLE
Fix no-height problem on smaller devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,10 +221,10 @@
     <footer>
       <div class="container">
         <div class="row">
-          <div class="col-md-8">
+          <div class="col-xs-12 col-md-8">
             Sitemap
           </div>
-          <div class="col-md-4">
+          <div class="col-xs-12 col-md-4">
             <strong>Questions or comments?</strong><br />
             Please feel free to <a href="http://www.gentoo.org/main/en/contact.xml">contact us</a>.
           </div>


### PR DESCRIPTION
On smaller devices col-md-* doesn't do anything. That leads to a problem on pages that contain only elements that float because the height is 0. For example: http://wiki.gentoo.org/wiki/Special:RecentChanges
Currently the footer links are under the .footericons div and therefore not clickable.